### PR TITLE
fix: unify env variable name to AMAP_WEBSERVICE_KEY

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function setWebServiceKey(key) {
  */
 async function ensureWebServiceKey() {
   // 优先从环境变量读取
-  let key = process.env.AMAP_KEY || process.env.AMAP_WEBSERVICE_KEY;
+  let key = process.env.AMAP_WEBSERVICE_KEY;
   
   if (!key) {
     // 尝试从配置文件读取
@@ -67,7 +67,7 @@ async function ensureWebServiceKey() {
     console.log('\n⚠️  未找到高德 Web Service Key');
     console.log('请访问以下地址创建应用并获取 Key:');
     console.log('https://lbs.amap.com/api/webservice/create-project-and-key\n');
-    throw new Error('请设置环境变量 AMAP_KEY 或提供高德 Web Service Key');
+    throw new Error('请设置环境变量 AMAP_WEBSERVICE_KEY 或提供高德 Web Service Key');
   }
   
   return key;

--- a/scripts/poi-search.js
+++ b/scripts/poi-search.js
@@ -4,7 +4,7 @@
  * POI 搜索脚本
  * 使用方法:
  * node scripts/poi-search.js --keywords=肯德基 --city=北京
- * 或设置环境变量: AMAP_KEY=your_key node scripts/poi-search.js --keywords=肯德基
+ * 或设置环境变量: AMAP_WEBSERVICE_KEY=your_key node scripts/poi-search.js --keywords=肯德基
  */
 
 const { searchPOI } = require('../index');
@@ -35,11 +35,11 @@ async function main() {
     process.exit(1);
   }
   
-  // 检查是否设置了 AMAP_KEY
-  if (!process.env.AMAP_KEY) {
-    console.error('❌ 请设置环境变量 AMAP_KEY');
+  // 检查是否设置了 AMAP_WEBSERVICE_KEY
+  if (!process.env.AMAP_WEBSERVICE_KEY) {
+    console.error('❌ 请设置环境变量 AMAP_WEBSERVICE_KEY');
     console.log('\n示例:');
-    console.log('export AMAP_KEY=your_amap_key');
+    console.log('export AMAP_WEBSERVICE_KEY=your_amap_key');
     console.log('node scripts/poi-search.js --keywords=美食 --location=116.397428,39.90923 --radius=1000');
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- 统一环境变量名称为 `AMAP_WEBSERVICE_KEY`，与 README 文档中的说明保持一致
- 修复 `scripts/poi-search.js` 中仅检查 `AMAP_KEY` 导致按 README 配置的用户无法运行命令行脚本的问题
- 更新 `index.js` 中的错误提示信息

## Problem

README 中记录的环境变量名为 `AMAP_WEBSERVICE_KEY`，但代码中存在不一致：
- `index.js` 优先读取 `AMAP_KEY`，`AMAP_WEBSERVICE_KEY` 仅作为 fallback
- `scripts/poi-search.js` 仅检查 `AMAP_KEY`，不兼容 `AMAP_WEBSERVICE_KEY`

用户按照 README 设置 `AMAP_WEBSERVICE_KEY` 后，通过命令行运行 `poi-search.js` 会直接报错退出。

## Changes
- `index.js`: 环境变量读取统一为 `process.env.AMAP_WEBSERVICE_KEY`，更新错误提示
- `scripts/poi-search.js`: 环境变量检查、错误提示和注释全部更新为 `AMAP_WEBSERVICE_KEY`

## Test plan
- [ ] 设置 `AMAP_WEBSERVICE_KEY` 环境变量后，`node scripts/poi-search.js --keywords=肯德基 --city=北京` 能正常运行
- [ ] 不设置任何环境变量时，错误提示正确引导用户设置 `AMAP_WEBSERVICE_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)